### PR TITLE
Remove global data in plugin

### DIFF
--- a/src/pytest_perfetto/plugin.py
+++ b/src/pytest_perfetto/plugin.py
@@ -27,125 +27,118 @@ PERFETTO_ARG_NAME: Final[str] = "perfetto_path"
 events: List[SerializableEvent] = []
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_sessionstart() -> Generator[None, None, None]:
-    # Called after the `Session` object has been created and before performing collection and
-    # entering the run test loop.
-    events.append(
-        BeginDurationEvent(
-            name="pytest session",
-            cat=Category("pytest"),
+class PytestPerfettoPlugin:
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_sessionstart(self) -> Generator[None, None, None]:
+        # Called after the `Session` object has been created and before performing collection and
+        # entering the run test loop.
+        events.append(
+            BeginDurationEvent(
+                name="pytest session",
+                cat=Category("pytest"),
+            )
         )
-    )
-    yield
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_sessionfinish(session: pytest.Session) -> Generator[None, None, None]:
-    # Called after whole test run finished, right before returning the exit status to the system
-    # https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_sessionfinish
-    events.append(EndDurationEvent())
-    perfetto_path: Union[Path, Notset] = session.config.getoption("perfetto_path")
-    if isinstance(perfetto_path, Path):
-        with perfetto_path.open("w") as file:
-            result = [asdict(event) for event in events]
-            for event in result:
-                # Python's time.time() produces timestamps using a seconds as its granularity,
-                # whilst perfetto uses a miceosecond granularity.
-                event["ts"] /= 1e-6
-
-            json.dump(result, file)
-    yield
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_collection() -> Generator[None, None, None]:
-    events.append(
-        BeginDurationEvent(
-            name="Start Collection",
-            cat=Category("pytest"),
-        )
-    )
-    yield
-
-
-def pytest_itemcollected(item: pytest.Item) -> None:
-    events.append(InstantEvent(name=f"[Item Collected] {item.nodeid}"))
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_collection_finish() -> Generator[None, None, None]:
-    events.append(EndDurationEvent())
-    yield
-
-
-# ===== Test running (runtest) hooks =====
-# https://docs.pytest.org/en/7.1.x/reference/reference.html#test-running-runtest-hooks
-
-
-def create_args_from_location(location: Tuple[str, Optional[int], str]) -> Dict[str, str]:
-    (file_name, line_number, test_name) = location
-
-    args = {"file_name": file_name, "test_name": test_name}
-
-    if line_number is not None:
-        args["line_number"] = str(line_number)
-
-    return args
-
-
-def pytest_runtest_logstart(nodeid: str, location: Tuple[str, Optional[int], str]) -> None:
-    events.append(
-        BeginDurationEvent(
-            name=nodeid,
-            args=create_args_from_location(location),
-            cat=Category("test"),
-        )
-    )
-
-
-def pytest_runtest_logfinish() -> None:
-    events.append(EndDurationEvent())
-
-
-def pytest_runtest_logreport(report: pytest.TestReport) -> None:
-    if report.when is None or report.when == "call":
-        return
-
-    events.append(
-        BeginDurationEvent(name=report.when, cat=Category("test"), ts=Timestamp(report.start))
-    )
-    events.append(EndDurationEvent(ts=Timestamp(report.stop)))
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_call() -> Generator[None, None, None]:
-    global events  # noqa: PLW0603
-    start_event = BeginDurationEvent(name="call", cat=Category("test"))
-    events.append(start_event)
-    with pyinstrument.Profiler() as profile:
         yield
-    if profile.last_session is not None:
-        events += render(profile.last_session, start_time=start_event.ts)
-    events.append(EndDurationEvent())
 
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_sessionfinish(self, session: pytest.Session) -> Generator[None, None, None]:
+        # Called after whole test run finished, right before returning the exit status to the system
+        # https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_sessionfinish
+        events.append(EndDurationEvent())
+        perfetto_path: Union[Path, Notset] = session.config.getoption("perfetto_path")
+        if isinstance(perfetto_path, Path):
+            with perfetto_path.open("w") as file:
+                result = [asdict(event) for event in events]
+                for event in result:
+                    # Python's time.time() produces timestamps using a seconds as its granularity,
+                    # whilst perfetto uses a miceosecond granularity.
+                    event["ts"] /= 1e-6
 
-# ===== Reporting hooks =====
+                json.dump(result, file)
+        yield
 
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_collection(self) -> Generator[None, None, None]:
+        events.append(
+            BeginDurationEvent(
+                name="Start Collection",
+                cat=Category("pytest"),
+            )
+        )
+        yield
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_fixture_setup(fixturedef: pytest.FixtureDef[Any]) -> Generator[None, None, None]:
-    args = {
-        "argnames": fixturedef.argnames,
-        "baseid": fixturedef.baseid,
-        "ids": fixturedef.ids,
-        "params": fixturedef.params,
-        "scope": fixturedef.scope,
-    }
-    events.append(BeginDurationEvent(name=fixturedef.argname, cat=Category("test"), args=args))
-    yield
-    events.append(EndDurationEvent())
-    pass
+    def pytest_itemcollected(self, item: pytest.Item) -> None:
+        events.append(InstantEvent(name=f"[Item Collected] {item.nodeid}"))
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_collection_finish(self) -> Generator[None, None, None]:
+        events.append(EndDurationEvent())
+        yield
+
+    # ===== Test running (runtest) hooks =====
+    # https://docs.pytest.org/en/7.1.x/reference/reference.html#test-running-runtest-hooks
+    @staticmethod
+    def create_args_from_location(location: Tuple[str, Optional[int], str]) -> Dict[str, str]:
+        (file_name, line_number, test_name) = location
+
+        args = {"file_name": file_name, "test_name": test_name}
+
+        if line_number is not None:
+            args["line_number"] = str(line_number)
+
+        return args
+
+    def pytest_runtest_logstart(
+        self, nodeid: str, location: Tuple[str, Optional[int], str]
+    ) -> None:
+        events.append(
+            BeginDurationEvent(
+                name=nodeid,
+                args=PytestPerfettoPlugin.create_args_from_location(location),
+                cat=Category("test"),
+            )
+        )
+
+    def pytest_runtest_logfinish(self) -> None:
+        events.append(EndDurationEvent())
+
+    def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:
+        if report.when is None or report.when == "call":
+            return
+
+        events.append(
+            BeginDurationEvent(name=report.when, cat=Category("test"), ts=Timestamp(report.start))
+        )
+        events.append(EndDurationEvent(ts=Timestamp(report.stop)))
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call(self) -> Generator[None, None, None]:
+        global events  # noqa: PLW0603
+        start_event = BeginDurationEvent(name="call", cat=Category("test"))
+        events.append(start_event)
+        with pyinstrument.Profiler() as profile:
+            yield
+        if profile.last_session is not None:
+            events += render(profile.last_session, start_time=start_event.ts)
+        events.append(EndDurationEvent())
+
+    # ===== Reporting hooks =====
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_fixture_setup(
+        self, fixturedef: pytest.FixtureDef[Any]
+    ) -> Generator[None, None, None]:
+        args = {
+            "argnames": fixturedef.argnames,
+            "baseid": fixturedef.baseid,
+            "ids": fixturedef.ids,
+            "params": fixturedef.params,
+            "scope": fixturedef.scope,
+        }
+        events.append(BeginDurationEvent(name=fixturedef.argname, cat=Category("test"), args=args))
+        yield
+        events.append(EndDurationEvent())
+        pass
 
 
 # ===== Initialization hooks =====
@@ -164,3 +157,4 @@ def pytest_configure(config: pytest.Config) -> None:
     option: Union[Path, Notset] = config.getoption(PERFETTO_ARG_NAME)
     if isinstance(option, Path) and option.is_dir():
         raise ValueError("The provided path must not be a directory")
+    config.pluginmanager.register(PytestPerfettoPlugin())


### PR DESCRIPTION
By encapsulating the contents of `plugin.py` inside of a class, we can avoid having to collect perfetto events into a list accessed through the global keyword.